### PR TITLE
Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Based on https://github.com/AnalogJ/docker-cron
+
+FROM debian:bookworm-slim
+
+RUN apt-get update && \
+    apt-get install -y \
+        busybox-static \
+        geographiclib-tools \
+        mariadb-client \
+        jq \
+        curl \
+    && mkdir -p /var/spool/cron/crontabs && \
+    rm -rf /etc/cron.*/* && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /blissey
+
+ENTRYPOINT ["sh", "-c", " \
+    env >> /etc/environment && \
+    ./settings.run && \
+    cat ./crontab.txt >> /var/spool/cron/crontabs/root && \
+    echo \"$@\" && \
+    exec \"$@\" \
+", "--"]
+
+CMD ["busybox", "crond", "-f", "-l", "2"]

--- a/README.md
+++ b/README.md
@@ -12,14 +12,23 @@ Processing is done on interval 15/60/1440/10080 minutes and can be displayed by 
 - enable save logs in controller config is you want them processed
 - mysql and jq installed
 
-## 2 Setup
+## 2 Instructions
 - clone Blissey, `git clone https://github.com/UnownHash/Blissey.git && cd Blissey`
 - create stats db and user (user needs to have access to stats/controller/golbat db)
 - copy and fill out config, `cp default_files/config.ini.example config.ini`
+
+### 2.1 Standard Setup
 - execute setting.run
 - add content of crontab.txt to your cron
 
-### 2.1 Geofences
+### 2.2 Docker Setup
+- Authenticate to [GitHub Packages's docker container registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry)
+- copy `docker-compose.yml.example` to `docker-compose.yml`
+- modify it to your needs
+- ``docker compose up -d``
+- ``settings.run`` & ``crontab.txt`` will get executed automatically
+
+### 2.3 Geofences
 Blissey needs quest and mon fences in order to aggregate data. 2 ways of doing this:<BR>
 1 Use Koji<BR>
 - set config.ini accordingly

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -6,6 +6,7 @@ services:
     networks:
       - scanner
     volumes:
+      #                       ↓ Must match dragonite_path in your config.ini
       - ./path/to/dragonite:/home/dkmur/Dragonite # Change according to your directory structure
       - ./:/blissey
       # Optional

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -1,0 +1,16 @@
+services:
+  blissey:
+    build: .
+    container_name: blissey
+    restart: unless-stopped
+    networks:
+      - scanner
+    volumes:
+      - ./path/to/dragonite:/home/dkmur/Dragonite # Change according to your directory structure
+      - ./:/blissey
+      # Optional
+      - /etc/timezone:/etc/timezone:ro
+      - /etc/localtime:/etc/localtime:ro
+
+networks:
+  scanner:


### PR DESCRIPTION
- Added a ``Dockerfile`` based on ``debian-slim`` since ``dpkg`` and ``geographiclib-tools`` are required and ``busybox crond`` was used since debian's cron doesn't have a way to redirect all the output to docker logs without modifying the crontab, this docker image includes all the necessary dependencies that Blissey requires
- Docker compose example and README updated.